### PR TITLE
Make meaning of AcquirableSessionTokens clearer

### DIFF
--- a/simple-model/CosmosDB.tla
+++ b/simple-model/CosmosDB.tla
@@ -79,7 +79,7 @@ SessionTokens == [
 
 \* The "not a session token" session token. It precedes all session tokens,
 \* and should be used when no session token is known / available.
-\* It is not a valid session token itself, but is usually compatible with them.
+\* It is not a valid session token itself, but is compatible with them.
 \*
 \* It is not a member of SessionTokens because it has an epoch of 0,
 \* which is special-cased such that it is valid at all epochs.
@@ -199,7 +199,8 @@ TypesOK ==
 
 \* Assuming session-consistent reads and writes,
 \* this operator describes the set of all session tokens that could be
-\* acquired during the current action.
+\* acquired during the current state, independent of session-consistent
+\* reads and writes.
 \*
 \* Note that the range of possible checkpoints is very broad: if the newest
 \* write to a key is very old, the current spec will consider the returned

--- a/simple-model/CosmosDB.tla
+++ b/simple-model/CosmosDB.tla
@@ -77,7 +77,10 @@ SessionTokens == [
     epoch: Epochs
 ]
 
-\* The "not a session token" session token.
+\* The "not a session token" session token. It precedes all session tokens,
+\* and should be used when no session token is known / available.
+\* It is not a valid session token itself, but is usually compatible with them.
+\*
 \* It is not a member of SessionTokens because it has an epoch of 0,
 \* which is special-cased such that it is valid at all epochs.
 \* A read or write operation can be given this token, and that
@@ -194,13 +197,17 @@ TypesOK ==
     /\ epoch \in Epochs
     /\ WriteConsistencyLevel \in ConsistencyLevels
 
-\* This operator can be used to generate a
-\* fresh session token. Combined with session-consistent reads and writes,
-\* the expectation is that one could model a client holding and progressively
-\* updating a session token using this operator and the ones defined near it.
+\* Assuming session-consistent reads and writes,
+\* this operator describes the set of all session tokens that could be
+\* acquired during the current action.
+\*
+\* Note that the range of possible checkpoints is very broad: if the newest
+\* write to a key is very old, the current spec will consider the returned
+\* token's checkpoint to point to that oldest index, even if 
+\* the checkpoint is older than readIndex.
 AcquirableSessionTokens == [
     epoch: {epoch},
-    checkpoint: readIndex..Len(log)
+    checkpoint: 0..(Len(log) + 1) \* +1 to account for incomplete writes
 ]
 
 \* Whether the database's current state accepts writes.

--- a/simple-model/CosmosDBProps.tla
+++ b/simple-model/CosmosDBProps.tla
@@ -433,6 +433,19 @@ SessionTokenWhenValid ==
             /\ token.epoch = epoch \/ token = NoSessionToken
             => SessionConsistencyRead(token, key) # {}
 
+SessionTokenAlwaysAcquirableRead ==
+    ReadConsistencyOK(SessionConsistency)
+    =>
+    \A key \in Keys :
+        { UpdateTokenFromRead(NoSessionToken, read)
+          : read \in SessionConsistencyRead(NoSessionToken, key) }
+        \subseteq AcquirableSessionTokens
+
+SessionTokenAlwaysAcquirableWrite ==
+    WriteConsistencyLevel = SessionConsistency
+    =>
+    WriteInitToken \in AcquirableSessionTokens
+
 \* ConsistentPrefix
 \* https://docs.microsoft.com/en-us/azure/cosmos-db/consistency-levels#consistent-prefix-consistency
 \* Note: consistent prefix does not seem to be observable

--- a/simple-model/MCCosmosDBProps.cfg
+++ b/simple-model/MCCosmosDBProps.cfg
@@ -35,6 +35,9 @@ INVARIANT
     BoundedStalenessReadsFollowReadIndex
     BoundedStalenessIsBounded
 
+    SessionTokenAlwaysAcquirableRead
+    SessionTokenAlwaysAcquirableWrite
+
     \* very slow:
     SessionConsistencyReadsMonotonicPerTokenSequence
     SessionConsistencyReadsFollowReadIndex

--- a/simple-model/MCCosmosDBProps.tla
+++ b/simple-model/MCCosmosDBProps.tla
@@ -8,7 +8,7 @@ CheckpointsImpl == LogIndicesImpl \cup {0}
 EpochsImpl == 1..3
 
 SpecificStateSpace ==
-    /\ Len(log) < Max(LogIndicesImpl)
+    /\ Len(log) < (Max(LogIndicesImpl) - 1)
     /\ epoch < Max(EpochsImpl)
 
 StalenessBoundImpl == 2


### PR DESCRIPTION
Based on some discussion with @lemmy, this commit makes the meaning of `AcquirableSessionTokens` clearer, since it was previously not well integrated with the rest of the spec.

As a result two new properties check that the definition works as intended, and some changes and comments document a surprising behavior that came up.